### PR TITLE
移除对packr的依赖，使用embed代替

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@
 ### 使用说明
 1. 安装编译
 ```shell script
-# 安装packr工具 需要go 1.16以上
-go install github.com/gobuffalo/packr/packr@latest
-
 # clone
 git clone --recurse-submodules https://github.com/ssbeatty/oms.git
 
@@ -51,9 +48,9 @@ yarn && yarn build
 
 # 打包 oms
 # linux
-packr build -o oms cmd/omsd/main.go
+go build -o oms cmd/omsd/main.go
 # win
-packr build -o oms.exe cmd/omsd/main.go
+go build -o oms.exe cmd/omsd/main.go
 ```
 
 2. 启动 创建config.yaml在可执行文件同级 运行即可

--- a/internal/web/controllers/page.go
+++ b/internal/web/controllers/page.go
@@ -8,11 +8,18 @@ import (
 	"net/http"
 	"oms/internal/models"
 	"oms/internal/web/websocket"
+	"oms/web"
 	"strconv"
 )
 
+const IndexPage = "omsUI/dist/index.html"
+
 func (s *Service) GetIndexPage(c *gin.Context) {
-	c.HTML(http.StatusOK, "index.html", nil)
+	bytes, err := web.EmbededFiles.ReadFile(IndexPage)
+	if err != nil {
+		fmt.Println("err", err)
+	}
+	c.Data(http.StatusOK, "", bytes)
 }
 
 var upGrader = wsl.Upgrader{

--- a/vendor/github.com/gin-contrib/static/.gitignore
+++ b/vendor/github.com/gin-contrib/static/.gitignore
@@ -1,0 +1,4 @@
+coverage.out
+dump.rdb
+*/vendor/*
+!*/vendor/vendor.json

--- a/vendor/github.com/gin-contrib/static/.travis.yml
+++ b/vendor/github.com/gin-contrib/static/.travis.yml
@@ -1,0 +1,33 @@
+language: go
+
+jobs:
+  fast_finish: true
+  include:
+  - go: 1.11.x
+    env: GO111MODULE=on
+  - go: 1.12.x
+    env: GO111MODULE=on
+  - go: 1.13.x
+  - go: 1.14.x
+  - go: 1.15.x
+  - go: 1.16.x
+  - go: master
+
+install:
+  - go get -t -v -d
+  - go get github.com/campoy/embedmd
+
+script:
+  - embedmd -d *.md
+  - go test -v -covermode=atomic -coverprofile=coverage.out
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
+notifications:
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/acc2c57482e94b44f557
+    on_success: change
+    on_failure: always
+    on_start: never

--- a/vendor/github.com/gin-contrib/static/LICENSE
+++ b/vendor/github.com/gin-contrib/static/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 gin-contrib
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/gin-contrib/static/README.md
+++ b/vendor/github.com/gin-contrib/static/README.md
@@ -1,0 +1,54 @@
+# static middleware
+
+[![Build Status](https://travis-ci.org/gin-contrib/static.svg)](https://travis-ci.org/gin-contrib/static)
+[![codecov](https://codecov.io/gh/gin-contrib/static/branch/master/graph/badge.svg)](https://codecov.io/gh/gin-contrib/static)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gin-contrib/static)](https://goreportcard.com/report/github.com/gin-contrib/static)
+[![GoDoc](https://godoc.org/github.com/gin-contrib/static?status.svg)](https://godoc.org/github.com/gin-contrib/static)
+
+Static middleware
+
+## Usage
+
+### Start using it
+
+Download and install it:
+
+```sh
+go get github.com/gin-contrib/static
+```
+
+Import it in your code:
+
+```go
+import "github.com/gin-contrib/static"
+```
+
+### Canonical example
+
+See the [example](example)
+
+[embedmd]:# (_example/simple/example.go go)
+```go
+package main
+
+import (
+	"github.com/gin-contrib/static"
+	"github.com/gin-gonic/gin"
+)
+
+func main() {
+	r := gin.Default()
+
+	// if Allow DirectoryIndex
+	//r.Use(static.Serve("/", static.LocalFile("/tmp", true)))
+	// set prefix
+	//r.Use(static.Serve("/static", static.LocalFile("/tmp", true)))
+
+	r.Use(static.Serve("/", static.LocalFile("/tmp", false)))
+	r.GET("/ping", func(c *gin.Context) {
+		c.String(200, "test")
+	})
+	// Listen and Server in 0.0.0.0:8080
+	r.Run(":8080")
+}
+```

--- a/vendor/github.com/gin-contrib/static/static.go
+++ b/vendor/github.com/gin-contrib/static/static.go
@@ -1,0 +1,70 @@
+package static
+
+import (
+	"net/http"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const INDEX = "index.html"
+
+type ServeFileSystem interface {
+	http.FileSystem
+	Exists(prefix string, path string) bool
+}
+
+type localFileSystem struct {
+	http.FileSystem
+	root    string
+	indexes bool
+}
+
+func LocalFile(root string, indexes bool) *localFileSystem {
+	return &localFileSystem{
+		FileSystem: gin.Dir(root, indexes),
+		root:       root,
+		indexes:    indexes,
+	}
+}
+
+func (l *localFileSystem) Exists(prefix string, filepath string) bool {
+	if p := strings.TrimPrefix(filepath, prefix); len(p) < len(filepath) {
+		name := path.Join(l.root, p)
+		stats, err := os.Stat(name)
+		if err != nil {
+			return false
+		}
+		if stats.IsDir() {
+			if !l.indexes {
+				index := path.Join(name, INDEX)
+				_, err := os.Stat(index)
+				if err != nil {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func ServeRoot(urlPrefix, root string) gin.HandlerFunc {
+	return Serve(urlPrefix, LocalFile(root, false))
+}
+
+// Static returns a middleware handler that serves static files in the given directory.
+func Serve(urlPrefix string, fs ServeFileSystem) gin.HandlerFunc {
+	fileserver := http.FileServer(fs)
+	if urlPrefix != "" {
+		fileserver = http.StripPrefix(urlPrefix, fileserver)
+	}
+	return func(c *gin.Context) {
+		if fs.Exists(urlPrefix, c.Request.URL.Path) {
+			fileserver.ServeHTTP(c.Writer, c.Request)
+			c.Abort()
+		}
+	}
+}

--- a/web/embed.go
+++ b/web/embed.go
@@ -1,0 +1,87 @@
+package web
+
+import (
+	"embed"
+	"errors"
+	"io"
+	"io/fs"
+	"net/http"
+	"path"
+	"strings"
+)
+
+//go:embed omsUI/dist
+var EmbededFiles embed.FS
+
+//func init() {
+//	data, _ := EmbededFiles.ReadFile("omsUI/dist/index.html")
+//	fmt.Println(string(data))
+//}
+
+type ServeFileSystem struct {
+	E    embed.FS
+	Path string
+}
+
+type File struct {
+	name string
+	fs.File
+}
+
+func (f *File) Readdir(count int) ([]fs.FileInfo, error) {
+	ff, ok := f.File.(fs.ReadDirFile)
+	if !ok {
+		return nil, &fs.PathError{Op: "readdir", Path: f.name, Err: errors.New("not implemented")}
+	}
+	fileList, err := ff.ReadDir(count)
+	if err != nil {
+		return nil, err
+	}
+	rspList := []fs.FileInfo{}
+	for _, v := range fileList {
+		temp, err := v.Info()
+		if err != nil {
+			return nil, err
+		}
+		rspList = append(rspList, temp)
+	}
+	return rspList, nil
+}
+
+func (f *File) Seek(offset int64, whence int) (int64, error) {
+	ff, ok := f.File.(io.Seeker)
+	if !ok {
+		return 0, &fs.PathError{Op: "Seek", Path: f.name, Err: errors.New("not implemented")}
+	}
+	return ff.Seek(offset, whence)
+}
+
+func (c *ServeFileSystem) Open(name string) (http.File, error) {
+	name = path.Join(c.Path, name)
+	f, err := c.E.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	ff := File{
+		name: name,
+		File: f,
+	}
+	return &ff, nil
+}
+
+func (c *ServeFileSystem) Exists(prefix string, filepath string) bool {
+	if p := strings.TrimPrefix(filepath, prefix); len(p) < len(filepath) {
+
+		p = path.Join(c.Path, p)
+		f, err := c.E.Open(p)
+		if err != nil {
+			return false
+		}
+		err = f.Close()
+		if err != nil {
+			return false
+		}
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
从1.16以来golang官方支持的embed是支持文件内嵌的方法，非常方便

现在可以去除第三方工具packr了